### PR TITLE
set file mime

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -71,12 +71,13 @@ module.exports = {
     // 生成上传对象
     const formUploader = new qiniu.form_up.FormUploader(zoneConfig)
 
-    const putExtra = new qiniu.form_up.PutExtra()
-
-
     return {
       upload(file) {
         return new Promise((resolve, reject) => {
+
+          // 指定文件类型
+          let putExtra = new qiniu.form_up.PutExtra(undefined,undefined,file.mime)
+
           // 定义key
           let key = `${prefix}/${file.hash}${file.ext}`
 
@@ -106,6 +107,10 @@ module.exports = {
       },
       uploadStream(file) {
         return new Promise((resolve, reject) => {
+
+          // 指定文件类型
+          let putExtra = new qiniu.form_up.PutExtra(undefined,undefined,file.mime)
+
            // 定义key
           let key = `${prefix}/${file.hash}${file.ext}`
           // 上传凭证选项


### PR DESCRIPTION
最近出现了上传图片，但七牛云类型显示为视频，以及上传视频，但七牛云类型显示图片的情况。

情况的具体原因我没有找到，开发环境上传是正常的，但生产环境，经常发生七牛云文件类型错误的情况

![image](https://github.com/yangfei4913438/provider-upload-qiniu-cloud/assets/22218688/384ab537-2400-42ca-a536-7eed7cdd9c68)

于是参照strapi官方 [s3 provider](https://github.com/strapi/strapi/tree/develop/packages/providers/upload-aws-s3) ，将文件类型上传给 七牛云，就没有问题了